### PR TITLE
Add reportOnly setting to allow setting CSP in report only mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ Example `config/content-security-policy.php`:
 
 return [
     'enabled' => true,
+    
+    'reportOnly' => false,
 
     'baseUri' => [
         "'none'",

--- a/src/models/Settings.php
+++ b/src/models/Settings.php
@@ -7,6 +7,8 @@ use craft\base\Model;
 class Settings extends Model
 {
     public $enabled = true;
+
+    public $reportOnly = false;
     
     public $baseUri = [
         "'none'",

--- a/src/services/Headers.php
+++ b/src/services/Headers.php
@@ -20,6 +20,8 @@ class Headers extends Component
 
         $csp = [];
 
+        $header = $settings->reportOnly ? 'Content-Security-Policy-Report-Only' : 'Content-Security-Policy';
+
         if (!empty($settings->baseUri)) {
             $csp['base-uri'] = $settings->baseUri;
         }
@@ -114,7 +116,7 @@ class Headers extends Component
         $cspValue = join('; ', $cspValues);
 
         Craft::$app->getResponse()->getHeaders()
-            ->set('Content-Security-Policy', $cspValue . ';');
+            ->set($header, $cspValue . ';');
     }
 
     /**


### PR DESCRIPTION
It's currently not possible to run CSP in report only mode.

Report only mode allows one to collect CSP violations without enforcing them thereby ensuring that no valid sources are blocked.

Set `'reportOnly' => true,`  in  `config/content-security-policy.php` to enable report only mode for CSP.

